### PR TITLE
fix: exclude junit-platform-launcher from unit-pioneer dependency

### DIFF
--- a/cloud-core-extension/pom.xml
+++ b/cloud-core-extension/pom.xml
@@ -76,6 +76,12 @@
             <artifactId>junit-pioneer</artifactId>
             <version>2.3.0</version>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.junit.platform</groupId>
+                    <artifactId>junit-platform-launcher</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
junit-platform-launcher 1.11.2 not compatible with junit-jupiter 5.12.2